### PR TITLE
Changed error message

### DIFF
--- a/src/GatewayClient.ts
+++ b/src/GatewayClient.ts
@@ -73,7 +73,7 @@ export class GatewayClient extends Eris.Client{
         super(token, options.erisOptions || {});
 
         if (!options) throw new Error('No options provided');
-        if (!options.shardsPerCluster) throw new Error('No function to get the first shard id provided.');
+        if (!options.shardsPerCluster) throw new Error('No ShardsPerCluster option provided');
 
         this.options.autoreconnect = true; // yes
 


### PR DESCRIPTION
- Changed error message for if no `shardsPerCluster` option is provided, as before it was misleading (Seems this error was meant for if there's no `getFirstShard` function, but is thrown when there's no `shardsPerCluster` option)